### PR TITLE
Align 'Frequently Asked Questions' Section to Center issue #123

### DIFF
--- a/style.css
+++ b/style.css
@@ -1039,7 +1039,7 @@ footer {
 
 /* end */
 
-FAQ Section */
+/* FAQ Section */
 .container_1 {
   width: 100%;
   margin: auto;


### PR DESCRIPTION
issue #123

It seems the issue was caused by a missing '/*' in the comment. I've fixed it.